### PR TITLE
Update apiVersion for k8s v1.17+ daemonset

### DIFF
--- a/kubernetes_daemonset.yaml
+++ b/kubernetes_daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   creationTimestamp: "2020-04-27T04:31:39Z"


### PR DESCRIPTION
K8s v1.17 or greater now require the apiVersion to change from `extensions/v1beta1` to `apps/v1` in order to deploy successfully.

This was detailed as per the official documentation of Kubernetes (Release notes - 1.16.0) - https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/